### PR TITLE
[FIX] Remove requirement for equal {participants x sessions} across pipelines/assessments

### DIFF
--- a/digest/app.py
+++ b/digest/app.py
@@ -151,6 +151,12 @@ def process_bagel(upload_contents, available_digest_nclicks, filenames):
             )
             is None
         ):
+            # Convert session column to string so numeric labels are not treated as numbers
+            #
+            # TODO: Any existing NaNs will currently be turned into "nan". (See open issue https://github.com/pandas-dev/pandas/issues/25353)
+            # Another side effect of allowing NaN sessions is that if this column has integer values, they will be read in as floats
+            # (before being converted to str) if there are NaNs in the column.
+            # This should not be a problem after we disallow NaNs value in "participant_id" and "session" columns, https://github.com/neurobagel/digest/issues/20
             bagel["session"] = bagel["session"].astype(str)
             session_list = bagel["session"].unique().tolist()
 

--- a/digest/utility.py
+++ b/digest/utility.py
@@ -207,7 +207,7 @@ def get_pipelines_overview(bagel: pd.DataFrame, schema: str) -> pd.DataFrame:
         columns=get_event_id_columns(bagel, schema),
         values=BAGEL_CONFIG[schema]["overview_col"],
         aggfunc="first",
-        fill_value=None,  # TODO: Check if default value makes sense
+        fill_value=None,  # TODO: Revisit this when we have an idea for a better fill value
         dropna=True,
     )
 

--- a/digest/utility.py
+++ b/digest/utility.py
@@ -117,7 +117,9 @@ def get_missing_required_columns(bagel: pd.DataFrame, schema_file: str) -> set:
     )
 
 
-def get_event_id_columns(bagel: pd.DataFrame, schema: str) -> Union[str, list]:
+def get_event_id_columns(
+    bagel: pd.DataFrame, schema: str
+) -> Union[str, list, None]:
     """
     Returns name(s) of columns which identify a unique assessment or processing pipeline.
 
@@ -177,7 +179,7 @@ def get_id_columns(data: pd.DataFrame) -> list:
 
 
 def get_duplicate_entries(data: pd.DataFrame, subset: list) -> pd.DataFrame:
-    """Returns a dataframe containing only duplicate entries in the input data."""
+    """Returns a dataframe containing all duplicate entries in the input data."""
     return data[data.duplicated(subset=subset, keep=False)]
 
 

--- a/digest/utility.py
+++ b/digest/utility.py
@@ -300,8 +300,8 @@ def get_schema_validation_errors(
         ).shape[0]
         > 0
     ):
-        # TODO: Switch to warning once toasts are enabled?
-        error_msg = f"The selected CSV contains duplicate entries across the following columns: {unique_value_id_columns}. Please try again."
+        # TODO: Switch to warning once alerts are implemented for errors?
+        error_msg = f"The selected CSV contains duplicate entries in the combination of: {unique_value_id_columns}. Please double check your input."
 
     return error_msg
 

--- a/digest/utility.py
+++ b/digest/utility.py
@@ -181,26 +181,6 @@ def get_duplicate_entries(data: pd.DataFrame, subset: list) -> pd.DataFrame:
     return data[data.duplicated(subset=subset, keep=False)]
 
 
-# TODO: Remove as function is no longer used
-def are_subjects_same_across_pipelines(
-    bagel: pd.DataFrame, schema: str
-) -> bool:
-    """Checks if subjects and sessions are the same across pipelines in the input."""
-    pipelines_dict = extract_pipelines(bagel, schema)
-
-    pipeline_subject_sessions = []
-    for df in pipelines_dict.values():
-        # per pipeline, rows are sorted first in case participants/sessions are out of order
-        pipeline_subject_sessions.append(
-            df.sort_values(get_id_columns(bagel)).loc[:, get_id_columns(bagel)]
-        )
-
-    return all(
-        pipeline.equals(pipeline_subject_sessions[0])
-        for pipeline in pipeline_subject_sessions
-    )
-
-
 def count_unique_subjects(data: pd.DataFrame) -> int:
     return (
         data["participant_id"].nunique()

--- a/requirements.txt
+++ b/requirements.txt
@@ -84,7 +84,7 @@ tqdm==4.65.0
 traitlets==5.9.0
 trio==0.22.0
 trio-websocket==0.9.2
-urllib3==1.26.14
+urllib3==1.26.18
 urllib3-secure-extra==0.1.0
 virtualenv==20.19.0
 waitress==2.1.2

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -81,7 +81,6 @@ def test_002_upload_invalid_imaging_bagel(test_server, bagels_path):
     """
     invalid_input_output = {
         "example_missing-col_bagel.csv": "missing the following required imaging metadata columns: {'pipeline_starttime'}",
-        "example_mismatch-subs_bagel.csv": "do not have the same number of subjects and sessions",
         "example_pheno_bagel.csv": "missing the following required imaging metadata columns",
     }
 

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -61,6 +61,75 @@ def test_wrap_df_column_values():
 
 
 @pytest.mark.parametrize(
+    "original_df,duplicates_df",
+    [
+        (
+            pd.DataFrame(
+                {
+                    "participant_id": ["sub-1", "sub-1", "sub-2", "sub-2"],
+                    "session": [1, 2, 1, 2],
+                    "assessment_name": ["moca", "moca", "moca", "moca"],
+                    "assessment_score": [21.0, 24.0, np.nan, 24.0],
+                }
+            ),
+            # Have to specify column dtypes as well because the df will otherwise not evaluate as equal to an empty subset of above df
+            pd.DataFrame(
+                {
+                    "participant_id": pd.Series([], dtype="object"),
+                    "session": pd.Series([], dtype="int64"),
+                    "assessment_name": pd.Series([], dtype="object"),
+                    "assessment_score": pd.Series([], dtype="float64"),
+                }
+            ),
+        ),
+        (
+            pd.DataFrame(
+                {
+                    "participant_id": ["sub-1", "sub-1", "sub-2", "sub-2"],
+                    "session": [1, 1, 1, 2],
+                    "assessment_name": ["moca", "moca", "moca", "moca"],
+                    "assessment_score": [21.0, 24.0, np.nan, 24.0],
+                }
+            ),
+            pd.DataFrame(
+                {
+                    "participant_id": ["sub-1", "sub-1"],
+                    "session": [1, 1],
+                    "assessment_name": ["moca", "moca"],
+                    "assessment_score": [21.0, 24.0],
+                }
+            ),
+        ),
+        (
+            pd.DataFrame(
+                {
+                    "participant_id": ["sub-1", "sub-1", "sub-2", "sub-2"],
+                    "session": [np.nan, np.nan, 1, 2],
+                    "assessment_name": ["moca", "moca", "moca", "moca"],
+                    "assessment_score": [21.0, 24.0, np.nan, 24.0],
+                }
+            ),
+            pd.DataFrame(
+                {
+                    "participant_id": ["sub-1", "sub-1"],
+                    "session": [np.nan, np.nan],
+                    "assessment_name": ["moca", "moca"],
+                    "assessment_score": [21.0, 24.0],
+                }
+            ),
+        ),
+    ],
+)
+def test_get_duplicate_entries(original_df, duplicates_df):
+    """Test that get_duplicate_entries() returns a dataframe containing the duplicate entries in a given dataframe."""
+
+    unique_value_id_columns = ["participant_id", "session", "assessment_name"]
+    assert util.get_duplicate_entries(
+        data=original_df, subset=unique_value_id_columns
+    ).equals(duplicates_df)
+
+
+@pytest.mark.parametrize(
     "column,nonmissing,missing,stats",
     [
         ("group", "3/3", "0/3", ["unique values", "most common value"]),


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Fixes #61 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- Removed unnecessary check for equal {participants x sessions} across pipelines (for imaging CSVs) or assessments (for phenotypic CSVs)
  - When `pivot`ing the long-format input to wide, pandas will simply create empty cells for any combinations that do not exist in the original data, which we think is fine for now
- ~Switched to using a method for reshaping the long input data to wide (`pd.pivot` -> `pd.pivot_table`) that has finer control over the aggregation method when there are duplicates, and values used to fill missing values in the resulting pivoted table~
  - EDIT: Sticking with `pd.pivot` due to known problems with `pd.pivot_table` silently dropping `NaN`s
- Added input check for duplicate entries for a given participant-session and pipeline/assessment combination (i.e., when there is >1 value for a participant-session for a specific pipeline or phenotypic measure)
  - When this happens, error out for now (`pivot_table` could theoretically handle this by keeping only the first occurrence in the resulting pivoted table, but this is not intuitive and may mean relevant data is lost - rather, we probably want to flag and tell users to fix duplicate observations)

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.
