### PR TITLE
Fix broken links in README and add markdown link checker

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,12 @@
 repos:
+  - repo: https://github.com/tcort/markdown-link-check
+    rev: v3.14.2
+    hooks:
+      - id: markdown-link-check
+        args:
+          - --quiet
+          - --config=md_link_check_config.json
+
   - repo: https://github.com/psf/black
     rev: 22.10.0
     hooks:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ It provides user-friendly options for querying data availability, along with int
 ## Quickstart
 Try out `digest` at https://digest.neurobagel.org/!
 
-You can find correctly formatted example input files [here](/example_bagels/) to test out dashboard functionality.
+You can find correctly formatted example input files [here](/example_inputs/) to test out dashboard functionality.
 
 ## Input schema
 `digest` supports long format TSVs that contain the columns specified in the [digest schemas](/schemas/) (see also the schema [README](https://github.com/neurobagel/digest/tree/main/schemas#readme)). 
@@ -30,7 +30,7 @@ At the moment, each digest file is expected to correspond to one dataset.
 
 ## Creating a dashboard-ready "digest" file
 While `digest` accepts any TSV compliant with one of the [digest schemas](/schemas/), the easiest way to obtain dashboard-ready files for pipeline derivative availability is to use the [Nipoppy](https://nipoppy.readthedocs.io/en/stable/) specification for organizing your neuroimaging dataset.
-Nipoppy provides dataset [trackers](https://nipoppy.readthedocs.io/en/stable/user_guide/tracking.html) that can automatically extract subjects' imaging data and pipeline output availability, producing `digest`-compatible processing status files.
+Nipoppy provides dataset [trackers](https://nipoppy.readthedocs.io/en/stable/how_to_guides/tracking/index.html) that can automatically extract subjects' imaging data and pipeline output availability, producing `digest`-compatible processing status files.
 
 For detailed instructions to get started using Nipoppy, see the [documentation](https://nipoppy.readthedocs.io/en/stable/). 
 
@@ -49,12 +49,7 @@ _*Nipoppy also provides a protocol for running processing pipelines from raw ima
 docker pull neurobagel/digest:nightly
 ```
 
-2. Currently, `digest` also relies on a local copy of the [`qpn_workflows`](https://github.com/neurodatascience/qpn_workflows) repository, which contains ready-to-use `digest` files that are automatically generated for the Quebec Parkinson Network data.
-```
-git clone https://github.com/neurodatascience/qpn_workflows.git
-```
-
-3. Run `digest` and mount the `qpn_workflows` directory into the container:
+2. Run `digest` and mount a directory containing ready-to-use digest files (e.g., `qpn_workflows`) into the container:
 ```bash
 docker run -d -p 8050:8050 -v ${PWD}/qpn_workflows:/app/qpn_workflows neurobagel/digest:nightly
 ```

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ _*Nipoppy also provides a protocol for running processing pipelines from raw ima
 docker pull neurobagel/digest:nightly
 ```
 
-2. Run `digest` and mount a directory containing ready-to-use digest files (e.g., [`qpn_workflows`](git clone https://github.com/neurodatascience/qpn_workflows.git), which contains digest files auto-generated for Quebec Parkinson Network data) into the container:
+2. Run `digest` and mount a directory containing ready-to-use digest files (e.g., [`qpn_workflows`](https://github.com/neurodatascience/qpn_workflows.git), 
+which contains digest files auto-generated for Quebec Parkinson Network data) into the container:
 ```bash
 docker run -d -p 8050:8050 -v ${PWD}/qpn_workflows:/app/qpn_workflows neurobagel/digest:nightly
 ```

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ _*Nipoppy also provides a protocol for running processing pipelines from raw ima
 docker pull neurobagel/digest:nightly
 ```
 
-2. Run `digest` and mount a directory containing ready-to-use digest files (e.g., `qpn_workflows`) into the container:
+2. Run `digest` and mount a directory containing ready-to-use digest files (e.g., [`qpn_workflows`](git clone https://github.com/neurodatascience/qpn_workflows.git), which contains digest files auto-generated for Quebec Parkinson Network data) into the container:
 ```bash
 docker run -d -p 8050:8050 -v ${PWD}/qpn_workflows:/app/qpn_workflows neurobagel/digest:nightly
 ```

--- a/md_link_check_config.json
+++ b/md_link_check_config.json
@@ -1,0 +1,9 @@
+{
+  "ignorePatterns": [
+    {"pattern": "^/"},
+    {"pattern": "^http://127\\.0\\.0\\.1"}
+  ],
+  "timeout": "120s",
+  "retryOn429": true,
+  "retryCount": 5
+}


### PR DESCRIPTION
## Summary
- Fix broken Nipoppy trackers URL: `user_guide/tracking.html` -> `how_to_guides/tracking/index.html` (closes #179)
- Fix `example_bagels/` -> `example_inputs/` (directory was renamed, link was stale)
- Remove broken `git clone` of `neurodatascience/qpn_workflows` from Docker section (repo returns 404), but keep the volume mount in the `docker run` invocation
- Add `markdown-link-check` pre-commit hook to catch future link rot (closes #167)

## Question
Is `neurodatascience/qpn_workflows` gone for good or just made private? If it's still available somewhere, we should add back the clone instruction with the correct URL.

## Test plan
- [x] Verify the Nipoppy trackers link resolves: https://nipoppy.readthedocs.io/en/stable/how_to_guides/tracking/index.html
- [x] Run `pre-commit run markdown-link-check --all-files` to validate remaining links

🤖 Generated with [Claude Code](https://claude.com/claude-code)
